### PR TITLE
fix: enable OIDC trusted publishing via npm plugin provenance option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,9 @@
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/npm",
+    ["@semantic-release/npm", {
+      "provenance": true
+    }],
     ["@semantic-release/git", {
       "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
## What failed

`@semantic-release/npm` requires `provenance: true` in its **plugin config** to activate the OIDC token exchange path. Setting `NPM_CONFIG_PROVENANCE=true` as an env var is not sufficient — the plugin's `verify-auth` step checks `pluginConfig.provenance`, not the env var, to determine whether to bypass the `NPM_TOKEN` requirement.

## Changes

- `.releaserc.json`: add `provenance: true` to the `@semantic-release/npm` plugin config
- `release.yml`: remove the now-redundant `NPM_CONFIG_PROVENANCE` env var

## Secondary error (resolved by fixing the primary)

`@semantic-release/github` tried to create a failure issue tagged with the `semantic-release` label, which doesn't exist in this repo, causing a 422. This only triggers on release failure, so it won't recur once the npm auth is working.

https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae)_