### PR TITLE
fix: restore NPM_TOKEN for reliable npm authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,9 @@
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/npm",
+    ["@semantic-release/npm", {
+      "provenance": true
+    }],
     ["@semantic-release/git", {
       "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
## Root cause

When the npm OIDC token exchange fails (e.g. the trusted publisher config on npmjs.com doesn't exactly match the repo/workflow), `@semantic-release/npm` logs the failure and returns `undefined` — silently falling through to the `NPM_TOKEN` check, which also has nothing, causing `ENONPMTOKEN`.

`provenance: true` in the plugin config does **not** control authentication — it only adds `--provenance` to the `npm publish` command for signed attestation.

## Fix

Add `NPM_TOKEN` back to the workflow env. This is the reliable auth path.

`provenance: true` stays in `.releaserc.json` — it still attaches a signed provenance attestation using the OIDC token separately from authentication (requires `id-token: write`, which the workflow already has).

## Required

Make sure the `NPM_TOKEN` secret (npm Automation token) is set in repo Settings → Secrets and variables → Actions.

https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae)_