### PR TITLE
feat: deploy demo to GitHub Pages on each release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy GitHub Pages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: demo/
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds a GitHub Pages deployment workflow that fires whenever semantic-release publishes a new release.

## What it deploys

The `demo/` folder — `index.html` + the pre-built `fs.js`. The shell and terminal JS are loaded from the unpkg CDN (`brsh@1`), so the demo always reflects the latest published version without needing a build step.

## One-time setup required

Before merging, enable GitHub Pages in the repo settings:

**Settings → Pages → Build and deployment → Source → GitHub Actions**

After that, every new release will automatically update the demo site.

https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae)_