### PR TITLE
fix: trigger Pages deployment via workflow_run instead of release event

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,10 @@
 name: Deploy GitHub Pages
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [master, main]
 
 permissions:
   pages: write
@@ -16,6 +18,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Root cause

GitHub Actions deliberately does not fire `release: published` (or any other event) when the event is caused by the `GITHUB_TOKEN`. This prevents infinite workflow loops, but it means semantic-release's automatically-created releases never trigger downstream workflows.

## Fix

Switch the Pages workflow trigger from `release: published` to `workflow_run` on the **Release** workflow completing. Also adds a `conclusion == 'success'` guard so a failed release doesn't deploy stale content.

https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqwo6ypXptg2JBw3jckmae)_